### PR TITLE
[option_quiet] Update wercker.yml to use `--quiet` option

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -42,7 +42,7 @@ build:
     - script:
         name: wait agent to start
         code: |
-          until bin/azk status; do sleep 1; done
+          until bin/azk status --quiet; do sleep 1; done
 
     - script:
         name: download azktcl


### PR DESCRIPTION
I updated the `wercker.yml` to use the option `--quiet` in the script "wait agent to start".
